### PR TITLE
add version get route

### DIFF
--- a/exe/ExampleMain.hs
+++ b/exe/ExampleMain.hs
@@ -60,6 +60,7 @@ main = do
     route
       [ ("targets", method GET targetsHandler)
       , ("health-private", method GET healthPrivateHandler)
+      , ("version", method GET versionHandler)
       , ("parse", method POST $ parseHandler tzs)
       ]
 
@@ -75,6 +76,23 @@ writeLazyContent lazy = writeContent $ LBS.toStrict lazy
 -- | Health check
 healthPrivateHandler :: Snap ()
 healthPrivateHandler = writeContent "ok\n"
+
+-- | Version check
+-- Dimensions are optional here, they will be given a default value of 0
+versionMap :: HashMap (Some Dimension) Integer
+versionMap = HashMap.fromList
+  [ ( This AmountOfMoney, 0 )
+  , ( This Time, 0 )
+  ]
+
+versionHandler :: Snap ()
+versionHandler = do
+  modifyResponse $ setHeader "Content-Type" "application/json"
+  writeLazyContent $ encode $
+    HashMap.fromList . map dimVersion $ HashMap.toList versionMap
+  where
+    dimVersion :: (Some Dimension, Integer) -> (Text, Integer)
+    dimVersion = (\(This d) -> toName d) *** id
 
 -- | Return which languages have which dimensions
 targetsHandler :: Snap ()

--- a/exe/ExampleMain.hs
+++ b/exe/ExampleMain.hs
@@ -78,11 +78,22 @@ healthPrivateHandler :: Snap ()
 healthPrivateHandler = writeContent "ok\n"
 
 -- | Version check
--- Dimensions are optional here, they will be given a default value of 0
+-- Only final entities are included here
+-- Not versioned: Regex, TimeGrain
 versionMap :: HashMap (Some Dimension) Integer
 versionMap = HashMap.fromList
   [ ( This AmountOfMoney, 0 )
+  , ( This Distance, 0 )
+  , ( This Duration, 0 )
+  , ( This Email, 0 )
+  , ( This Numeral, 0 )
+  , ( This Ordinal, 0 )
+  , ( This PhoneNumber, 0 )
+  , ( This Quantity, 0 )
+  , ( This Temperature, 0 )
   , ( This Time, 0 )
+  , ( This Url, 0 )
+  , ( This Volume, 0 )
   ]
 
 versionHandler :: Snap ()


### PR DESCRIPTION
We would like all external services to return a monotonically increasing version number to allow us to decide when to retrain entities.