### PR TITLE
de: added rules to Numeral and AmountOfMoney

### DIFF
--- a/Duckling/AmountOfMoney/DE/Corpus.hs
+++ b/Duckling/AmountOfMoney/DE/Corpus.hs
@@ -1,0 +1,60 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+-- of patent rights can be found in the PATENTS file in the same directory.
+
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Duckling.AmountOfMoney.DE.Corpus
+  ( corpus
+  ) where
+
+import Data.String
+import Prelude
+
+import Duckling.AmountOfMoney.Types
+import Duckling.Locale
+import Duckling.Resolve
+import Duckling.Testing.Types
+
+corpus :: Corpus
+corpus = (testContext {locale = makeLocale DE Nothing}, testOptions, allExamples)
+
+allExamples :: [Example]
+allExamples = concat
+  [ examples (simple EUR 20)
+             [ "20€"
+             , "€20"
+             , "20 euros"
+             , "20 Euro"
+             , "20 Euros"
+             , "EUR 20"
+             ]
+  , examples (simple EUR 29.99)
+             [ "EUR29,99"
+             ]
+  , examples (simple EUR 7000000)
+             [ "€7 Millionen"
+             ]
+  , examples (simple EUR 10000000)
+             [ "EUR 10 Mio"
+             ]
+  , examples (simple EUR 100000)
+             [ "100T€"
+             ]
+  , examples (simple EUR 50000)
+             [ "50T€"
+             , "€50T"
+             ]
+  , examples (simple EUR 67318205.45)
+             [ "67.318.205,45 €"
+             ]
+  , examples (simple EUR 8199999.999999999)
+             [ "EUR 8,2 Millionen"
+             , "€ 8,2 Millionen"
+             , "€8,2 Millionen"
+             ]
+  ]

--- a/Duckling/AmountOfMoney/DE/Rules.hs
+++ b/Duckling/AmountOfMoney/DE/Rules.hs
@@ -1,0 +1,141 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+-- of patent rights can be found in the PATENTS file in the same directory.
+
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Duckling.AmountOfMoney.DE.Rules
+  ( rules
+  ) where
+
+import Data.Maybe
+import Data.String
+import Prelude
+
+import Duckling.AmountOfMoney.Helpers
+import Duckling.AmountOfMoney.Types (Currency(..), AmountOfMoneyData (..))
+import Duckling.Dimensions.Types
+import Duckling.Numeral.Helpers (isNatural)
+import Duckling.Numeral.Types (NumeralData (..))
+import Duckling.Types
+import qualified Duckling.AmountOfMoney.Types as TAmountOfMoney
+import qualified Duckling.Numeral.Types as TNumeral
+
+ruleUnitAmount :: Rule
+ruleUnitAmount = Rule
+  { name = "<unit> <amount>"
+  , pattern =
+    [ Predicate isCurrencyOnly
+    , dimension Numeral
+    ]
+  , prod = \case
+      (Token AmountOfMoney AmountOfMoneyData{TAmountOfMoney.currency = c}:
+       Token Numeral NumeralData{TNumeral.value = v}:
+       _) -> Just . Token AmountOfMoney . withValue v $ currencyOnly c
+      _ -> Nothing
+  }
+
+ruleDollar :: Rule
+ruleDollar = Rule
+  { name = "dollar"
+  , pattern =
+    [ regex "doll?ars?"
+    ]
+  , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly Dollar
+  }
+
+ruleCent :: Rule
+ruleCent = Rule
+  { name = "cent"
+  , pattern =
+    [ regex "cents?"
+    ]
+  , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly Cent
+  }
+
+rulePounds :: Rule
+rulePounds = Rule
+  { name = "£"
+  , pattern =
+    [ regex "(pound|pfund)s?"
+    ]
+  , prod = \_ -> Just . Token AmountOfMoney $ currencyOnly Pound
+  }
+
+ruleIntersectAndNumeral :: Rule
+ruleIntersectAndNumeral = Rule
+  { name = "intersect (and number)"
+  , pattern =
+    [ Predicate isWithoutCents
+    , regex "und"
+    , Predicate isNatural
+    ]
+  , prod = \tokens -> case tokens of
+      (Token AmountOfMoney fd:
+       _:
+       Token Numeral NumeralData{TNumeral.value = c}:
+       _) -> Just . Token AmountOfMoney $ withCents c fd
+      _ -> Nothing
+  }
+
+ruleIntersectXCents :: Rule
+ruleIntersectXCents = Rule
+  { name = "intersect (X cents)"
+  , pattern =
+    [ Predicate isWithoutCents
+    , Predicate isCents
+    ]
+  , prod = \tokens -> case tokens of
+      (Token AmountOfMoney fd:
+       Token AmountOfMoney AmountOfMoneyData{TAmountOfMoney.value = Just c}:
+       _) -> Just . Token AmountOfMoney $ withCents c fd
+      _ -> Nothing
+  }
+
+ruleIntersectAndXCents :: Rule
+ruleIntersectAndXCents = Rule
+  { name = "intersect (and X cents)"
+  , pattern =
+    [ Predicate isWithoutCents
+    , regex "und"
+    , Predicate isCents
+    ]
+  , prod = \tokens -> case tokens of
+      (Token AmountOfMoney fd:
+       _:
+       Token AmountOfMoney AmountOfMoneyData{TAmountOfMoney.value = Just c}:
+       _) -> Just . Token AmountOfMoney $ withCents c fd
+      _ -> Nothing
+  }
+
+ruleIntersect :: Rule
+ruleIntersect = Rule
+  { name = "intersect"
+  , pattern =
+    [ Predicate isWithoutCents
+    , Predicate isNatural
+    ]
+  , prod = \tokens -> case tokens of
+      (Token AmountOfMoney fd:
+       Token Numeral NumeralData{TNumeral.value = c}:
+       _) -> Just . Token AmountOfMoney $ withCents c fd
+      _ -> Nothing
+  }
+
+rules :: [Rule]
+rules =
+  [ ruleUnitAmount
+  , ruleCent
+  , ruleDollar
+  , ruleIntersect
+  , ruleIntersectAndNumeral
+  , ruleIntersectAndXCents
+  , ruleIntersectXCents
+  , rulePounds
+  ]

--- a/Duckling/Numeral/DE/Corpus.hs
+++ b/Duckling/Numeral/DE/Corpus.hs
@@ -94,6 +94,8 @@ allExamples = concat
              , "100000"
              , "100K"
              , "100k"
+             , "100T"
+             , "100t"
              ]
   , examples (NumeralValue 3000000)
              [ "3M"
@@ -123,6 +125,9 @@ allExamples = concat
              ]
   , examples (NumeralValue 200000)
              [ "zwei hundert tausend"
+             , "200 tausend"
+             , "0,2 Millionen"
+             , "0,2 mio"
              ]
   , examples (NumeralValue 721012)
              [ "sieben hundert einundzwanzig tausend zwölf"

--- a/Duckling/Numeral/DE/Rules.hs
+++ b/Duckling/Numeral/DE/Rules.hs
@@ -163,16 +163,17 @@ ruleIntersect = Rule
 
 ruleNumeralsSuffixesKMG :: Rule
 ruleNumeralsSuffixesKMG = Rule
-  { name = "numbers suffixes (K, M, G)"
+  { name = "numbers suffixes (K, T, M, G)"
   , pattern =
     [ dimension Numeral
-    , regex "([kmg])(?=[\\W\\$€]|$)"
+    , regex "([kmgt])(?=[\\W\\$€]|$)"
     ]
   , prod = \tokens -> case tokens of
       (Token Numeral NumeralData{TNumeral.value = v}:
        Token RegexMatch (GroupMatch (match:_)):
        _) -> case Text.toLower match of
          "k" -> double $ v * 1e3
+         "t" -> double $ v * 1e3
          "m" -> double $ v * 1e6
          "g" -> double $ v * 1e9
          _ -> Nothing
@@ -201,7 +202,7 @@ rulePowersOfTen :: Rule
 rulePowersOfTen = Rule
   { name = "powers of tens"
   , pattern =
-    [ regex "(hunderte?|tausende?|million(en)?)"
+    [ regex "(hunderte?|tausende?|mi(o|llion(en)?))"
     ]
   , prod = \tokens -> case tokens of
       (Token RegexMatch (GroupMatch (match:_)):_) -> case Text.toLower match of
@@ -209,6 +210,7 @@ rulePowersOfTen = Rule
         "hunderte"  -> double 1e2 >>= withGrain 2 >>= withMultipliable
         "tausend"   -> double 1e3 >>= withGrain 3 >>= withMultipliable
         "tausende"  -> double 1e3 >>= withGrain 3 >>= withMultipliable
+        "mio"       -> double 1e6 >>= withGrain 6 >>= withMultipliable
         "million"   -> double 1e6 >>= withGrain 6 >>= withMultipliable
         "millionen" -> double 1e6 >>= withGrain 6 >>= withMultipliable
         _           -> Nothing

--- a/Duckling/Rules/DE.hs
+++ b/Duckling/Rules/DE.hs
@@ -18,6 +18,7 @@ module Duckling.Rules.DE
 import Duckling.Dimensions.Types
 import Duckling.Locale
 import Duckling.Types
+import qualified Duckling.AmountOfMoney.DE.Rules as AmountOfMoney
 import qualified Duckling.Duration.DE.Rules as Duration
 import qualified Duckling.Ordinal.DE.Rules as Ordinal
 import qualified Duckling.Numeral.DE.Rules as Numeral
@@ -32,7 +33,7 @@ localeRules region (This (CustomDimension dim)) = dimLocaleRules region dim
 localeRules _ _ = []
 
 langRules :: Some Dimension -> [Rule]
-langRules (This AmountOfMoney) = []
+langRules (This AmountOfMoney) = AmountOfMoney.rules
 langRules (This Distance) = []
 langRules (This Duration) = Duration.rules
 langRules (This Email) = []

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -197,6 +197,8 @@ library
                      , Duckling.AmountOfMoney.EN.ZA.Rules
                      , Duckling.AmountOfMoney.BG.Corpus
                      , Duckling.AmountOfMoney.BG.Rules
+                     , Duckling.AmountOfMoney.DE.Corpus
+                     , Duckling.AmountOfMoney.DE.Rules
                      , Duckling.AmountOfMoney.ES.Corpus
                      , Duckling.AmountOfMoney.ES.Rules
                      , Duckling.AmountOfMoney.FR.Corpus
@@ -714,6 +716,7 @@ test-suite duckling-test
                      , Duckling.AmountOfMoney.AR.Tests
                      , Duckling.AmountOfMoney.EN.Tests
                      , Duckling.AmountOfMoney.BG.Tests
+                     , Duckling.AmountOfMoney.DE.Tests
                      , Duckling.AmountOfMoney.ES.Tests
                      , Duckling.AmountOfMoney.FR.Tests
                      , Duckling.AmountOfMoney.GA.Tests

--- a/tests/Duckling/AmountOfMoney/DE/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/DE/Tests.hs
@@ -1,0 +1,23 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+-- of patent rights can be found in the PATENTS file in the same directory.
+
+
+module Duckling.AmountOfMoney.DE.Tests
+  ( tests ) where
+
+import Prelude
+import Data.String
+import Test.Tasty
+
+import Duckling.Dimensions.Types
+import Duckling.Testing.Asserts
+import Duckling.AmountOfMoney.DE.Corpus
+
+tests :: TestTree
+tests = testGroup "DE Tests"
+  [ makeCorpusTest [This AmountOfMoney] corpus
+  ]

--- a/tests/Duckling/AmountOfMoney/Tests.hs
+++ b/tests/Duckling/AmountOfMoney/Tests.hs
@@ -17,6 +17,7 @@ import Test.Tasty
 import qualified Duckling.AmountOfMoney.AR.Tests as AR
 import qualified Duckling.AmountOfMoney.EN.Tests as EN
 import qualified Duckling.AmountOfMoney.BG.Tests as BG
+import qualified Duckling.AmountOfMoney.DE.Tests as DE
 import qualified Duckling.AmountOfMoney.ES.Tests as ES
 import qualified Duckling.AmountOfMoney.FR.Tests as FR
 import qualified Duckling.AmountOfMoney.GA.Tests as GA
@@ -37,6 +38,7 @@ tests = testGroup "AmountOfMoney Tests"
   [ AR.tests
   , EN.tests
   , BG.tests
+  , DE.tests
   , ES.tests
   , FR.tests
   , GA.tests

--- a/tests/Duckling/Testing/Asserts.hs
+++ b/tests/Duckling/Testing/Asserts.hs
@@ -84,8 +84,8 @@ makeCorpusTest targets (context, options, xs) = testCase "Corpus Tests" $
           [] -> assertFailure $ "empty result on " ++ show input
           (_:_:_) -> assertFailure $
             show (length restTokens) ++ " tokens found for " ++ show input
-          _ -> assertFailure $ "don't fully match " ++ show input
-        [token] -> assertBool ("don't pass predicate on " ++ show input) $
+          _ -> assertFailure $ "don't fully match " ++ show input ++ show tokens
+        [token] -> assertBool ("don't pass predicate on " ++ show input ++ show tokens) $
           predicate context token
         _ -> assertFailure $ show (length fullRangeTokens)
           ++ " different ambiguous parses on " ++ show input


### PR DESCRIPTION
Fix "Monetary Amount" extraction by duckling in German:

- [x] Umsatz €8,2 Millionen: does not extract the €.
  - added `<unit> <amount>` rule for DE language
- [x] Not extracting Mio. Dzt. sind EUR 10 Mio
  - added `mio` as a million multiplier in `Numeral.DE`
- [x] Not correctly extracting numbers with quantifier T: Bitte wie beantragt mit nur 100T€ (should be 100K EUR)
  - added `T` as a thousand unit multiplier in `Numeral.DE`

Mostly copied from the `*.ES` files, which also include euro(pean) examples.

All test cases added pass.