### PR TITLE
(reinfer) extract mm numerals

### DIFF
--- a/Duckling/Numeral/EN/Rules.hs
+++ b/Duckling/Numeral/EN/Rules.hs
@@ -294,7 +294,7 @@ ruleSuffixes = Rule
   { name = "suffixes (K,M,G))"
   , pattern =
     [ dimension Numeral
-    , regex "(k|m|mln|bar|mio|mil|mill|mn|bn|g|b|bln|bn|t|tln|tn)(?=[\\W$€¢£]|$)"
+    , regex "(k|m|mln|bar|mio|mil|mill|mm|mn|bn|g|b|bln|bn|t|tln|tn)(?=[\\W$€¢£]|$)"
     ]
   , prod = \tokens -> case tokens of
       (Token Numeral nd : Token RegexMatch (GroupMatch (match : _)):_) -> do
@@ -305,6 +305,7 @@ ruleSuffixes = Rule
           "mio" -> Just 1e6
           "mil" -> Just 1e6
           "mill" -> Just 1e6
+          "mm" -> Just 1e6
           "mn" -> Just 1e6
           "bar" -> Just 1e6
           "g" -> Just 1e9


### PR DESCRIPTION
Similarly to https://github.com/reinfer/duckling/pull/7, we should extract `mm` as "million".