### PR TITLE
Time: fix overlapping extraction of dates

### DIFF
--- a/Duckling/Time/EN/Rules.hs
+++ b/Duckling/Time/EN/Rules.hs
@@ -46,10 +46,31 @@ ruleIntersect = Rule
     , Predicate $ or . sequence [isNotLatent, isGrainOfTime TG.Year]
     ]
   , prod = \tokens -> case tokens of
-      (Token Time td1:Token Time td2:_) -> if td1 /= td2 then
+      (Token Time td1:Token Time td2:_) -> if (isValidIntersection td1 td2) then
         Token Time . notLatent <$> intersect td1 td2 else Nothing
       _ -> Nothing
   }
+
+-- Fixing issue around 10-July-2022 11-July-2022 getting badly extracted into July-2022 11-July-2022
+isValidIntersection :: TimeData -> TimeData -> Bool
+isValidIntersection td1 td2 
+  | td1 == td2 = False
+  | otherwise = case (timePred td1, timePred td2) of 
+    ((TTime.TimeDatePredicate a1 b1 c1 d1 e1 f1 g1 h1), (TTime.TimeDatePredicate a2 b2 c2 d2 e2 f2 g2 h2)) -> 
+        compare a1 a2 &&
+        compare b1 b2 &&
+        compare c1 c2 &&
+        compare d1 d2 &&
+        compare e1 e2 &&
+        compare f1 f2 &&
+        compare g1 g2 &&
+        compare h1 h2
+    _ -> True
+  where 
+  compare :: Maybe a -> Maybe a -> Bool
+  compare (Just a) (Just b) = False
+  compare _ _ = True
+    
 
 ruleIntersectOf :: Rule
 ruleIntersectOf = Rule

--- a/Duckling/Time/Types.hs
+++ b/Duckling/Time/Types.hs
@@ -88,9 +88,10 @@ instance Ord TimeData where
       z -> z
 
 instance Show TimeData where
-  show (TimeData _ latent grain _ form dir _ holiday) =
+  show (TimeData predicate latent grain _ form dir _ holiday) =
     "TimeData{" ++
-    "latent=" ++ show latent ++
+    "predicate=" ++ show predicate ++
+    ", latent=" ++ show latent ++
     ", grain=" ++ show grain ++
     ", form=" ++ show form ++
     ", direction=" ++ show dir ++
@@ -326,6 +327,7 @@ mkIntersectPredicate
         unify g1 g2 <*>
         unify h1 h2)
   where
+  unify :: Eq a => Maybe a -> Maybe a -> Maybe (Maybe a)
   unify Nothing a = Just a
   unify a Nothing = Just a
   unify ma@(Just a) (Just b)

--- a/tests/Duckling/Time/EN/Tests.hs
+++ b/tests/Duckling/Time/EN/Tests.hs
@@ -156,6 +156,7 @@ intersectTests = testCase "Intersect Test" $
     xs = [ ("tomorrow July", 2)
          , ("Mar tonight", 2)
          , ("Feb tomorrow", 1) -- we are in February
+         , ("Jul-2022 13-Jul-2022", 2)
          ]
 
 rangeTests :: TestTree


### PR DESCRIPTION
In this PR:
- Extending what gets printed when showing a `TimeData`, to display the content of the predicate
- Changing the logic to handle `TimeDatePredicate` intersections. This logic is used to merge spans of text together that form a more specific date (e.g. "June" + "2020" -> "June 2020"). It would compare any attributes (hour, day, month etc) and if one of the attribute in one date is not set or if both are equal then return the set one, otherwise reject the intersection as not valid. Unfortunately, accepting cases where the two attributes are the same led to spurious extractions such as `Jul-2020 13-Jul-2020` getting extracted as a single date. We therefore changed the logic to reject any intersection where both fields are set, even if identical, to prevent these edge cases. We might end up with some extractions that don't get concatenated together, but with some local testing we could not find any.